### PR TITLE
Pin the sljit version used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,52 +1,32 @@
 name: CI
 
-on:
-  push:
-  pull_request:
-    branches:
-      # Branches from forks have the form 'user:branch-name' so we only run
-      # this job on pull_request events for branches that look like fork
-      # branches. Without this we would end up running this job twice for non
-      # forked PRs, once for the push and then once for opening the PR.
-      - '**:**'
-      - master
+on: [push, pull_request]
+
 env:
   USE_SLJIT_COMMIT: 19309dc09600fa422c16c5453adc721f6a6e9c81
 
 jobs:
   build:
     name: ${{ matrix.cmake-build-type }}-build [${{ matrix.compiler }}, cmake-${{ matrix.cmake-version }}]
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:
-        compiler: [gcc-9, clang-10]
-        cmake-version: [3.19]
+        compiler: [gcc-12, clang-14]
+        cmake-version: ['3.27']
         cmake-build-type: [Release, RelWithDebInfo]
         include:
-          - compiler: gcc-4.8
-            cmake-version: 3.12
+          - compiler: gcc-9
+            cmake-version: '3.12'
             cmake-build-type: Release
-          - compiler: gcc-5
-            cmake-version: 3.13
+          - compiler: gcc-11
+            cmake-version: '3.18'
             cmake-build-type: Release
-          - compiler: gcc-6
-            cmake-version: 3.14
+          - compiler: clang-12
+            cmake-version: '3.15'
             cmake-build-type: Release
-          - compiler: gcc-7
-            cmake-version: 3.15
-            cmake-build-type: Release
-          - compiler: gcc-8
-            cmake-version: 3.16
-            cmake-build-type: Release
-          - compiler: clang-3.9
-            cmake-version: 3.17
-            cmake-build-type: Release
-          - compiler: clang-7
-            cmake-version: 3.18
-            cmake-build-type: Release
-          - compiler: clang-9
-            cmake-version: 3.19
+          - compiler: clang-13
+            cmake-version: '3.20'
             cmake-build-type: Release
 
     steps:
@@ -54,13 +34,11 @@ jobs:
       run: sudo apt install ${{ matrix.compiler }} libpcap-dev
 
     - name: Setup CMake
-      run: |
-        wget https://cmake.org/files/v${{ matrix.cmake-version }}/cmake-${{ matrix.cmake-version }}.0-Linux-x86_64.sh -O /tmp/cmake.sh
-        sudo sh /tmp/cmake.sh --prefix=/usr/local/ --exclude-subdir
-        # Make sure we use correct version
-        cmake --version | grep -c ${{ matrix.cmake-version }}.0
+      uses: jwlawson/actions-setup-cmake@v1
+      with:
+        cmake-version: ${{ matrix.cmake-version }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Create install folder
       run: cmake -E make_directory $RUNNER_TEMP/install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on: [push, pull_request]
 
 env:
+  # Use a sljit version that is known to compile with bpjit-netbsd.
+  # This commit is from: Sun Feb 28 18:47:02 2021 +0100
   USE_SLJIT_COMMIT: 19309dc09600fa422c16c5453adc721f6a6e9c81
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ on:
       # forked PRs, once for the push and then once for opening the PR.
       - '**:**'
       - master
+env:
+  USE_SLJIT_COMMIT: 19309dc09600fa422c16c5453adc721f6a6e9c81
 
 jobs:
   build:
@@ -64,7 +66,10 @@ jobs:
       run: cmake -E make_directory $RUNNER_TEMP/install
 
     - name: Download, build and install dependency sljit
-      run: DESTDIR=$RUNNER_TEMP/install make install-sljit
+      run: |
+        DESTDIR=$RUNNER_TEMP/install \
+        USE_SLJIT_COMMIT=${{ env.USE_SLJIT_COMMIT }} \
+        make install-sljit
 
     - name: Create build folder
       run: cmake -E make_directory build

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ PREFIX?=/usr/local
 CPPFLAGS += -Isrc/ -I$(DESTDIR)$(PREFIX)/include/
 CFLAGS += -O2 -Wall -Werror
 
+# The sljit commit (hashtag or branch) that is downloaded and installed
+# by the make target: install-sljit
+USE_SLJIT_COMMIT?=master
+
 lib=libbpfjit.a
 src=src/net/bpfjit.c
 headers=src/net/bpf.h src/net/bpfjit.h
@@ -31,7 +35,7 @@ install: $(lib)
 sljit = libsljit.a
 
 $(sljit):
-	curl -L https://github.com/zherczeg/sljit/archive/master.tar.gz | \
+	curl -L https://github.com/zherczeg/sljit/archive/$(USE_SLJIT_COMMIT).tar.gz | \
 		tar xz --one-top-level=sljit --strip=1
 	$(MAKE) -C sljit
 	$(AR) rvs $@ sljit/bin/sljitLir.o

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PREFIX?=/usr/local
 CPPFLAGS += -Isrc/ -I$(DESTDIR)$(PREFIX)/include/
 CFLAGS += -O2 -Wall -Werror
 
-# The sljit commit (hashtag or branch) that is downloaded and installed
+# The sljit commit (hash, branch or tag) that is downloaded and installed
 # by the make target: install-sljit
 USE_SLJIT_COMMIT?=master
 

--- a/test/test.c
+++ b/test/test.c
@@ -52,7 +52,7 @@ unsigned int jitcall(bpfjit_func_t fn, const uint8_t *pkt, unsigned int wirelen,
 
 /* Test that JIT compilation of an empty bpf program fails */
 void tc_bpfjit_empty() {
-    struct bpf_insn dummy;
+    struct bpf_insn dummy = {};
     bpfjit_func_t code;
 
     code = bpfjit_generate_code(NULL, &dummy, 0);


### PR DESCRIPTION
Use a known working sljit version in CI to make sure test-runs are predictable and reproducible.

Update build matrix to use readily available compilers and use the actions-setup-cmake helper.
Correcting build failure for >= gcc-11.
