### PR TITLE
Patch bpfjit to build with latest sljit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ on: [push, pull_request]
 
 env:
   # Use a sljit version that is known to compile with bpjit-netbsd.
-  # This commit is from: Sun Feb 28 18:47:02 2021 +0100
-  USE_SLJIT_COMMIT: 19309dc09600fa422c16c5453adc721f6a6e9c81
+  # This commit is from: Tue Sep 12 21:29:11 2023 -0700
+  USE_SLJIT_COMMIT: 3dcdb25754363db2cd34dbd1cd9a6a6b880cadae
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ install-sljit: $(sljit)
 	install -m 644 sljit/sljit_src/sljitLir.h \
                        sljit/sljit_src/sljitConfig.h \
                        sljit/sljit_src/sljitConfigInternal.h \
+                       sljit/sljit_src/sljitConfigCPU.h \
                        $(DESTDIR)$(PREFIX)/include
 
 # Test of library

--- a/patches/bpf.h.patch
+++ b/patches/bpf.h.patch
@@ -1,5 +1,5 @@
 diff --git a/src/net/bpf.h b/src/net/bpf.h
-index 71efd9a..59fdf0e 100644
+index bc9d3dd..1f0c174 100644
 --- a/src/net/bpf.h
 +++ b/src/net/bpf.h
 @@ -40,7 +40,11 @@
@@ -15,7 +15,7 @@ index 71efd9a..59fdf0e 100644
  #include <sys/time.h>
  
  /* BSD style release date */
-@@ -216,7 +220,8 @@ struct bpf_hdr32 {
+@@ -219,7 +223,8 @@ struct bpf_hdr32 {
  #endif
  
  /* Pull in data-link level type codes. */
@@ -25,7 +25,7 @@ index 71efd9a..59fdf0e 100644
  
  /*
   * The instruction encodings.
-@@ -356,6 +361,8 @@ struct bpf_aux_data {
+@@ -359,6 +364,8 @@ struct bpf_aux_data {
   */
  #define	BPF_MEMWORDS		16
  
@@ -34,7 +34,7 @@ index 71efd9a..59fdf0e 100644
  /*
   * bpf_memword_init_t: bits indicate which words in the external memory
   * store will be initialised by the caller before BPF program execution.
-@@ -364,7 +371,8 @@ typedef uint32_t bpf_memword_init_t;
+@@ -367,7 +374,8 @@ typedef uint32_t bpf_memword_init_t;
  #define	BPF_MEMWORD_INIT(k)	(UINT32_C(1) << (k))
  
  /* Note: two most significant bits are reserved by bpfjit. */
@@ -44,7 +44,7 @@ index 71efd9a..59fdf0e 100644
  
  #ifdef _KERNEL
  /*
-@@ -372,8 +380,9 @@ __CTASSERT(BPF_MEMWORDS + 2 <= sizeof(bpf_memword_init_t) * NBBY);
+@@ -375,8 +383,9 @@ __CTASSERT(BPF_MEMWORDS + 2 <= sizeof(bpf_memword_init_t) * NBBY);
   */
  #define	BPF_MAX_MEMWORDS	30
  
@@ -56,7 +56,7 @@ index 71efd9a..59fdf0e 100644
  #endif
  
  /*
-@@ -555,10 +564,11 @@ void	bpf_jit_freecode(bpfjit_func_t);
+@@ -596,10 +605,11 @@ void	bpf_jit_freecode(bpfjit_func_t);
  
  #endif
  
@@ -69,5 +69,5 @@ index 71efd9a..59fdf0e 100644
 -u_int	bpf_filter_with_aux_data(const struct bpf_insn *, const u_char *, u_int, u_int, const struct bpf_aux_data *);
 +/* u_int	bpf_filter_with_aux_data(const struct bpf_insn *, const u_char *, u_int, u_int, const struct bpf_aux_data *); */
  
- 
- __END_DECLS
+ /*
+  * events to be tracked by bpf_register_track_event callbacks

--- a/patches/bpfjit.c.patch
+++ b/patches/bpfjit.c.patch
@@ -1,5 +1,5 @@
 diff --git a/src/net/bpfjit.c b/src/net/bpfjit.c
-index a0c9820..31d10e2 100644
+index a0c9820..17afa4e 100644
 --- a/src/net/bpfjit.c
 +++ b/src/net/bpfjit.c
 @@ -33,7 +33,8 @@
@@ -12,18 +12,16 @@ index a0c9820..31d10e2 100644
  #endif
  
  #include <sys/types.h>
-@@ -603,8 +604,9 @@ emit_xcall(struct sljit_compiler *compiler, bpfjit_hint_t hints,
- 		return status;
+@@ -684,7 +685,8 @@ emit_cop(struct sljit_compiler *compiler, bpfjit_hint_t hints,
  
- 	/* fn(buf, k, &err); */
--	status = sljit_emit_ijump(compiler,
--	    SLJIT_CALL3,
-+	/* Updated for latest version of sljit */
-+	status = sljit_emit_icall(compiler,
-+	    SLJIT_CALL, SLJIT_RET(SW) | SLJIT_ARG1(SW) | SLJIT_ARG2(SW) | SLJIT_ARG3(SW),
- 	    SLJIT_IMM, SLJIT_FUNC_OFFSET(fn));
- 	if (status != SLJIT_SUCCESS)
- 		return status;
+ 	if (BPF_MISCOP(pc->code) == BPF_COP) {
+ 		call_reg = SLJIT_IMM;
+-		call_off = SLJIT_FUNC_OFFSET(bc->copfuncs[pc->k]);
++		/* Updated for latest version of sljit */
++		call_off = SLJIT_FUNC_ADDR(bc->copfuncs[pc->k]);
+ 	} else {
+ 		/* if (X >= bc->nfuncs) return 0; */
+ 		jump = sljit_emit_cmp(compiler,
 @@ -761,8 +763,9 @@ emit_cop(struct sljit_compiler *compiler, bpfjit_hint_t hints,
  	if (status != SLJIT_SUCCESS)
  		return status;
@@ -32,23 +30,115 @@ index a0c9820..31d10e2 100644
 -	    SLJIT_CALL3, call_reg, call_off);
 +	/* Updated for latest version of sljit */
 +	status = sljit_emit_icall(compiler,
-+	    SLJIT_CALL, SLJIT_RET(SW) | SLJIT_ARG1(SW) | SLJIT_ARG2(SW) | SLJIT_ARG3(SW), call_reg, call_off);
++	    SLJIT_CALL, SLJIT_ARGS3(W, W, W, W), call_reg, call_off);
  	if (status != SLJIT_SUCCESS)
  		return status;
  
-@@ -1195,8 +1198,9 @@ emit_moddiv(struct sljit_compiler *compiler, const struct bpf_insn *pc)
+@@ -1110,8 +1113,9 @@ emit_pow2_moddiv(struct sljit_compiler *compiler, const struct bpf_insn *pc)
+ 		}
+ 
+ 		if (shift != 0) {
++			/* Updated for latest version of sljit */
+ 			status = sljit_emit_op2(compiler,
+-			    SLJIT_LSHR|SLJIT_I32_OP,
++			    SLJIT_LSHR|SLJIT_32,
+ 			    BJ_AREG, 0,
+ 			    BJ_AREG, 0,
+ 			    SLJIT_IMM, shift);
+@@ -1173,7 +1177,8 @@ emit_moddiv(struct sljit_compiler *compiler, const struct bpf_insn *pc)
+ 		return status;
+ 
+ #if defined(BPFJIT_USE_UDIV)
+-	status = sljit_emit_op0(compiler, SLJIT_UDIV|SLJIT_I32_OP);
++	/* Updated for latest version of sljit */
++	status = sljit_emit_op0(compiler, SLJIT_UDIV|SLJIT_32);
+ 
+ 	if (BPF_OP(pc->code) == BPF_DIV) {
+ #if BJ_AREG != SLJIT_R0
+@@ -1195,10 +1200,11 @@ emit_moddiv(struct sljit_compiler *compiler, const struct bpf_insn *pc)
  	if (status != SLJIT_SUCCESS)
  		return status;
  #else
 -	status = sljit_emit_ijump(compiler,
 -	    SLJIT_CALL2,
+-	    SLJIT_IMM, xdiv ? SLJIT_FUNC_OFFSET(divide) :
+-		SLJIT_FUNC_OFFSET(modulus));
 +	/* Updated for latest version of sljit */
 +	status = sljit_emit_icall(compiler,
-+	    SLJIT_CALL, SLJIT_RET(SW) | SLJIT_ARG1(SW) | SLJIT_ARG2(SW),
- 	    SLJIT_IMM, xdiv ? SLJIT_FUNC_OFFSET(divide) :
- 		SLJIT_FUNC_OFFSET(modulus));
++	    SLJIT_CALL, SLJIT_ARGS2(W, W, W),
++	    SLJIT_IMM, xdiv ? SLJIT_FUNC_ADDR(divide) :
++		SLJIT_FUNC_ADDR(modulus));
  
-@@ -2190,7 +2194,8 @@ bpfjit_generate_code(const bpf_ctx_t *bc,
+ #if BJ_AREG != SLJIT_RETURN_REG
+ 	status = sljit_emit_op1(compiler,
+@@ -1601,7 +1607,7 @@ alu_to_op(const struct bpf_insn *pc, int *res)
+ 
+ 	/*
+ 	 * Note: all supported 64bit arches have 32bit multiply
+-	 * instruction so SLJIT_I32_OP doesn't have any overhead.
++	 * instruction so SLJIT_32 doesn't have any overhead.
+ 	 */
+ 	switch (BPF_OP(pc->code)) {
+ 	case BPF_ADD:
+@@ -1611,7 +1617,8 @@ alu_to_op(const struct bpf_insn *pc, int *res)
+ 		*res = SLJIT_SUB;
+ 		return true;
+ 	case BPF_MUL:
+-		*res = SLJIT_MUL|SLJIT_I32_OP;
++		/* Updated for latest version of sljit */
++		*res = SLJIT_MUL|SLJIT_32;
+ 		return true;
+ 	case BPF_OR:
+ 		*res = SLJIT_OR;
+@@ -1626,7 +1633,8 @@ alu_to_op(const struct bpf_insn *pc, int *res)
+ 		*res = SLJIT_SHL;
+ 		return k < 32;
+ 	case BPF_RSH:
+-		*res = SLJIT_LSHR|SLJIT_I32_OP;
++		/* Updated for latest version of sljit */
++		*res = SLJIT_LSHR|SLJIT_32;
+ 		return k < 32;
+ 	default:
+ 		return false;
+@@ -1642,9 +1650,10 @@ jmp_to_cond(const struct bpf_insn *pc, bool negate, int *res)
+ 
+ 	/*
+ 	 * Note: all supported 64bit arches have 32bit comparison
+-	 * instructions so SLJIT_I32_OP doesn't have any overhead.
++	 * instructions so SLJIT_32 doesn't have any overhead.
+ 	 */
+-	*res = SLJIT_I32_OP;
++	/* Updated for latest version of sljit */
++	*res = SLJIT_32;
+ 
+ 	switch (BPF_OP(pc->code)) {
+ 	case BPF_JGT:
+@@ -1937,9 +1946,11 @@ generate_insn_code(struct sljit_compiler *compiler, bpfjit_hint_t hints,
+ 
+ 		case BPF_ALU:
+ 			if (pc->code == (BPF_ALU|BPF_NEG)) {
+-				status = sljit_emit_op1(compiler,
+-				    SLJIT_NEG,
++				/* Updated for latest version of sljit */
++				status = sljit_emit_op2(compiler,
++				    SLJIT_SUB,
+ 				    BJ_AREG, 0,
++				    SLJIT_IMM, 0,
+ 				    BJ_AREG, 0);
+ 				if (status != SLJIT_SUCCESS)
+ 					goto fail;
+@@ -1969,8 +1980,9 @@ generate_insn_code(struct sljit_compiler *compiler, bpfjit_hint_t hints,
+ 
+ 			/* division by zero? */
+ 			if (src == BPF_X) {
++				/* Updated for latest version of sljit */
+ 				jump = sljit_emit_cmp(compiler,
+-				    SLJIT_EQUAL|SLJIT_I32_OP,
++				    SLJIT_EQUAL|SLJIT_32,
+ 				    BJ_XREG, 0,
+ 				    SLJIT_IMM, 0);
+ 				if (jump == NULL)
+@@ -2190,7 +2202,8 @@ bpfjit_generate_code(const bpf_ctx_t *bc,
  	if (!optimize(bc, insns, insn_dat, insn_count, &initmask, &hints))
  		goto fail;
  
@@ -58,17 +148,17 @@ index a0c9820..31d10e2 100644
  	if (compiler == NULL)
  		goto fail;
  
-@@ -2198,7 +2203,8 @@ bpfjit_generate_code(const bpf_ctx_t *bc,
+@@ -2198,7 +2211,8 @@ bpfjit_generate_code(const bpf_ctx_t *bc,
  	sljit_compiler_verbose(compiler, stderr);
  #endif
  
 -	status = sljit_emit_enter(compiler, 0, 2, nscratches(hints),
 +	/* Updated for latest version of sljit */
-+	status = sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW) | SLJIT_ARG2(SW), nscratches(hints),
++	status = sljit_emit_enter(compiler, 0, SLJIT_ARGS2(W, W, W), nscratches(hints),
  	    NSAVEDS, 0, 0, sizeof(struct bpfjit_stack));
  	if (status != SLJIT_SUCCESS)
  		goto fail;
-@@ -2305,6 +2311,6 @@ fail:
+@@ -2305,6 +2319,6 @@ fail:
  void
  bpfjit_free_code(bpfjit_func_t code)
  {

--- a/src/net/bpfjit.c
+++ b/src/net/bpfjit.c
@@ -604,9 +604,8 @@ emit_xcall(struct sljit_compiler *compiler, bpfjit_hint_t hints,
 		return status;
 
 	/* fn(buf, k, &err); */
-	/* Updated for latest version of sljit */
-	status = sljit_emit_icall(compiler,
-	    SLJIT_CALL, SLJIT_RET(SW) | SLJIT_ARG1(SW) | SLJIT_ARG2(SW) | SLJIT_ARG3(SW),
+	status = sljit_emit_ijump(compiler,
+	    SLJIT_CALL3,
 	    SLJIT_IMM, SLJIT_FUNC_OFFSET(fn));
 	if (status != SLJIT_SUCCESS)
 		return status;
@@ -686,7 +685,8 @@ emit_cop(struct sljit_compiler *compiler, bpfjit_hint_t hints,
 
 	if (BPF_MISCOP(pc->code) == BPF_COP) {
 		call_reg = SLJIT_IMM;
-		call_off = SLJIT_FUNC_OFFSET(bc->copfuncs[pc->k]);
+		/* Updated for latest version of sljit */
+		call_off = SLJIT_FUNC_ADDR(bc->copfuncs[pc->k]);
 	} else {
 		/* if (X >= bc->nfuncs) return 0; */
 		jump = sljit_emit_cmp(compiler,
@@ -765,7 +765,7 @@ emit_cop(struct sljit_compiler *compiler, bpfjit_hint_t hints,
 
 	/* Updated for latest version of sljit */
 	status = sljit_emit_icall(compiler,
-	    SLJIT_CALL, SLJIT_RET(SW) | SLJIT_ARG1(SW) | SLJIT_ARG2(SW) | SLJIT_ARG3(SW), call_reg, call_off);
+	    SLJIT_CALL, SLJIT_ARGS3(W, W, W, W), call_reg, call_off);
 	if (status != SLJIT_SUCCESS)
 		return status;
 
@@ -1113,8 +1113,9 @@ emit_pow2_moddiv(struct sljit_compiler *compiler, const struct bpf_insn *pc)
 		}
 
 		if (shift != 0) {
+			/* Updated for latest version of sljit */
 			status = sljit_emit_op2(compiler,
-			    SLJIT_LSHR|SLJIT_I32_OP,
+			    SLJIT_LSHR|SLJIT_32,
 			    BJ_AREG, 0,
 			    BJ_AREG, 0,
 			    SLJIT_IMM, shift);
@@ -1176,7 +1177,8 @@ emit_moddiv(struct sljit_compiler *compiler, const struct bpf_insn *pc)
 		return status;
 
 #if defined(BPFJIT_USE_UDIV)
-	status = sljit_emit_op0(compiler, SLJIT_UDIV|SLJIT_I32_OP);
+	/* Updated for latest version of sljit */
+	status = sljit_emit_op0(compiler, SLJIT_UDIV|SLJIT_32);
 
 	if (BPF_OP(pc->code) == BPF_DIV) {
 #if BJ_AREG != SLJIT_R0
@@ -1200,9 +1202,9 @@ emit_moddiv(struct sljit_compiler *compiler, const struct bpf_insn *pc)
 #else
 	/* Updated for latest version of sljit */
 	status = sljit_emit_icall(compiler,
-	    SLJIT_CALL, SLJIT_RET(SW) | SLJIT_ARG1(SW) | SLJIT_ARG2(SW),
-	    SLJIT_IMM, xdiv ? SLJIT_FUNC_OFFSET(divide) :
-		SLJIT_FUNC_OFFSET(modulus));
+	    SLJIT_CALL, SLJIT_ARGS2(W, W, W),
+	    SLJIT_IMM, xdiv ? SLJIT_FUNC_ADDR(divide) :
+		SLJIT_FUNC_ADDR(modulus));
 
 #if BJ_AREG != SLJIT_RETURN_REG
 	status = sljit_emit_op1(compiler,
@@ -1605,7 +1607,7 @@ alu_to_op(const struct bpf_insn *pc, int *res)
 
 	/*
 	 * Note: all supported 64bit arches have 32bit multiply
-	 * instruction so SLJIT_I32_OP doesn't have any overhead.
+	 * instruction so SLJIT_32 doesn't have any overhead.
 	 */
 	switch (BPF_OP(pc->code)) {
 	case BPF_ADD:
@@ -1615,7 +1617,8 @@ alu_to_op(const struct bpf_insn *pc, int *res)
 		*res = SLJIT_SUB;
 		return true;
 	case BPF_MUL:
-		*res = SLJIT_MUL|SLJIT_I32_OP;
+		/* Updated for latest version of sljit */
+		*res = SLJIT_MUL|SLJIT_32;
 		return true;
 	case BPF_OR:
 		*res = SLJIT_OR;
@@ -1630,7 +1633,8 @@ alu_to_op(const struct bpf_insn *pc, int *res)
 		*res = SLJIT_SHL;
 		return k < 32;
 	case BPF_RSH:
-		*res = SLJIT_LSHR|SLJIT_I32_OP;
+		/* Updated for latest version of sljit */
+		*res = SLJIT_LSHR|SLJIT_32;
 		return k < 32;
 	default:
 		return false;
@@ -1646,9 +1650,10 @@ jmp_to_cond(const struct bpf_insn *pc, bool negate, int *res)
 
 	/*
 	 * Note: all supported 64bit arches have 32bit comparison
-	 * instructions so SLJIT_I32_OP doesn't have any overhead.
+	 * instructions so SLJIT_32 doesn't have any overhead.
 	 */
-	*res = SLJIT_I32_OP;
+	/* Updated for latest version of sljit */
+	*res = SLJIT_32;
 
 	switch (BPF_OP(pc->code)) {
 	case BPF_JGT:
@@ -1941,9 +1946,11 @@ generate_insn_code(struct sljit_compiler *compiler, bpfjit_hint_t hints,
 
 		case BPF_ALU:
 			if (pc->code == (BPF_ALU|BPF_NEG)) {
-				status = sljit_emit_op1(compiler,
-				    SLJIT_NEG,
+				/* Updated for latest version of sljit */
+				status = sljit_emit_op2(compiler,
+				    SLJIT_SUB,
 				    BJ_AREG, 0,
+				    SLJIT_IMM, 0,
 				    BJ_AREG, 0);
 				if (status != SLJIT_SUCCESS)
 					goto fail;
@@ -1973,8 +1980,9 @@ generate_insn_code(struct sljit_compiler *compiler, bpfjit_hint_t hints,
 
 			/* division by zero? */
 			if (src == BPF_X) {
+				/* Updated for latest version of sljit */
 				jump = sljit_emit_cmp(compiler,
-				    SLJIT_EQUAL|SLJIT_I32_OP,
+				    SLJIT_EQUAL|SLJIT_32,
 				    BJ_XREG, 0,
 				    SLJIT_IMM, 0);
 				if (jump == NULL)
@@ -2204,7 +2212,7 @@ bpfjit_generate_code(const bpf_ctx_t *bc,
 #endif
 
 	/* Updated for latest version of sljit */
-	status = sljit_emit_enter(compiler, 0, SLJIT_ARG1(SW) | SLJIT_ARG2(SW), nscratches(hints),
+	status = sljit_emit_enter(compiler, 0, SLJIT_ARGS2(W, W, W), nscratches(hints),
 	    NSAVEDS, 0, 0, sizeof(struct bpfjit_stack));
 	if (status != SLJIT_SUCCESS)
 		goto fail;


### PR DESCRIPTION
Update the bpfjit code (and patch files) to handle all non-backward compatible API changes in latest [sljit](https://github.com/zherczeg/sljit/commit/3dcdb25754363db2cd34dbd1cd9a6a6b880cadae).

Supported sljit version range with this PR is
from: [6807c7a8faa894e9f468f42e4ab7928a147099d1](https://github.com/zherczeg/sljit/commit/6807c7a8faa894e9f468f42e4ab7928a147099d1)   (Fri Apr 1 06:12:19 2022 +0000)
to:   [3dcdb25754363db2cd34dbd1cd9a6a6b880cadae](https://github.com/zherczeg/sljit/commit/3dcdb25754363db2cd34dbd1cd9a6a6b880cadae)   (Tue Sep 12 21:29:11 2023 -0700)

Following API changes are handled:

- Remove SLJIT_NEG. Instead substraction from immedate 0 is preferred.
commit [6807c7a8faa894e9f468f42e4ab7928a147099d1](https://github.com/zherczeg/sljit/commit/6807c7a8faa894e9f468f42e4ab7928a147099d1)
Date:  Fri Apr 1 06:12:19 2022 +0000

- The SLJIT_FUNC_OFFSET macro is renamed to SLJIT_FUNC_ADDR
commit [8d0f668fad91ca1d6c8afb3b72eeeeb34db41bee](https://github.com/zherczeg/sljit/commit/8d0f668fad91ca1d6c8afb3b72eeeeb34db41bee)
Date:  Sat Feb 5 11:58:29 2022 +0000

- Rework function argument list descriptor macros
commit [7f0afb25e402ad491f2cd1c94a864a2ed75e2df4](https://github.com/zherczeg/sljit/commit/7f0afb25e402ad491f2cd1c94a864a2ed75e2df4)
Date:  Tue Feb 1 07:33:46 2022 +0000

- Change SLJIT_I32_OP and SLJIT_F32_OP to SLJIT_32
commit [cf594d74ddae92fd7f6050441e10b4be3d708a42](https://github.com/zherczeg/sljit/commit/cf594d74ddae92fd7f6050441e10b4be3d708a42)
Date:  Tue Jan 25 05:17:17 2022 +0000