### PR TITLE
Support latest version of sljit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ on: [push, pull_request]
 
 env:
   # Use a sljit version that is known to compile with bpjit-netbsd.
-  # This commit is from: Tue Sep 12 21:29:11 2023 -0700
-  USE_SLJIT_COMMIT: 3dcdb25754363db2cd34dbd1cd9a6a6b880cadae
+  # This commit is from: Fri Jan 17 11:39:36 2025 +0100
+  USE_SLJIT_COMMIT: 85782cfb77ae4f52e06975655aa4d37b08511ba0
 
 jobs:
   build:

--- a/patches/bpfjit.c.patch
+++ b/patches/bpfjit.c.patch
@@ -1,5 +1,5 @@
 diff --git a/src/net/bpfjit.c b/src/net/bpfjit.c
-index a0c9820..17afa4e 100644
+index a0c9820..08cc032 100644
 --- a/src/net/bpfjit.c
 +++ b/src/net/bpfjit.c
 @@ -33,7 +33,8 @@
@@ -138,26 +138,28 @@ index a0c9820..17afa4e 100644
  				    BJ_XREG, 0,
  				    SLJIT_IMM, 0);
  				if (jump == NULL)
-@@ -2190,7 +2202,8 @@ bpfjit_generate_code(const bpf_ctx_t *bc,
- 	if (!optimize(bc, insns, insn_dat, insn_count, &initmask, &hints))
- 		goto fail;
- 
--	compiler = sljit_create_compiler(NULL);
-+	/* Updated for latest version of sljit */
-+	compiler = sljit_create_compiler(NULL, NULL);
- 	if (compiler == NULL)
- 		goto fail;
- 
-@@ -2198,7 +2211,8 @@ bpfjit_generate_code(const bpf_ctx_t *bc,
+@@ -2198,8 +2210,9 @@ bpfjit_generate_code(const bpf_ctx_t *bc,
  	sljit_compiler_verbose(compiler, stderr);
  #endif
  
 -	status = sljit_emit_enter(compiler, 0, 2, nscratches(hints),
+-	    NSAVEDS, 0, 0, sizeof(struct bpfjit_stack));
 +	/* Updated for latest version of sljit */
 +	status = sljit_emit_enter(compiler, 0, SLJIT_ARGS2(W, W, W), nscratches(hints),
- 	    NSAVEDS, 0, 0, sizeof(struct bpfjit_stack));
++	    NSAVEDS, sizeof(struct bpfjit_stack));
  	if (status != SLJIT_SUCCESS)
  		goto fail;
+ 
+@@ -2290,7 +2303,8 @@ bpfjit_generate_code(const bpf_ctx_t *bc,
+ 		goto fail;
+ 	}
+ 
+-	rv = sljit_generate_code(compiler);
++	/* Updated for latest version of sljit */
++	rv = sljit_generate_code(compiler, 0, NULL);
+ 
+ fail:
+ 	if (compiler != NULL)
 @@ -2305,6 +2319,6 @@ fail:
  void
  bpfjit_free_code(bpfjit_func_t code)

--- a/src/net/bpfjit.c
+++ b/src/net/bpfjit.c
@@ -2202,8 +2202,7 @@ bpfjit_generate_code(const bpf_ctx_t *bc,
 	if (!optimize(bc, insns, insn_dat, insn_count, &initmask, &hints))
 		goto fail;
 
-	/* Updated for latest version of sljit */
-	compiler = sljit_create_compiler(NULL, NULL);
+	compiler = sljit_create_compiler(NULL);
 	if (compiler == NULL)
 		goto fail;
 
@@ -2213,7 +2212,7 @@ bpfjit_generate_code(const bpf_ctx_t *bc,
 
 	/* Updated for latest version of sljit */
 	status = sljit_emit_enter(compiler, 0, SLJIT_ARGS2(W, W, W), nscratches(hints),
-	    NSAVEDS, 0, 0, sizeof(struct bpfjit_stack));
+	    NSAVEDS, sizeof(struct bpfjit_stack));
 	if (status != SLJIT_SUCCESS)
 		goto fail;
 
@@ -2304,7 +2303,8 @@ bpfjit_generate_code(const bpf_ctx_t *bc,
 		goto fail;
 	}
 
-	rv = sljit_generate_code(compiler);
+	/* Updated for latest version of sljit */
+	rv = sljit_generate_code(compiler, 0, NULL);
 
 fail:
 	if (compiler != NULL)


### PR DESCRIPTION
Updates source and patches to handle the following API changes in sljit:
- sljit_create_compiler https://github.com/zherczeg/sljit/commit/40eff814723711574dbae4cf2229132fd9e021e1

- sljit_generate_code https://github.com/zherczeg/sljit/commit/40eff814723711574dbae4cf2229132fd9e021e1

- sljit_emit_enter https://github.com/zherczeg/sljit/commit/c85dd1dd9740dfcf053d53b2e14a2a820d43871b

CI updated to build with the latest sljit version, which currently is https://github.com/zherczeg/sljit/commit/85782cfb77ae4f52e06975655aa4d37b08511ba0 (Jan 17 2025)
* No changes in NetBSD that required a lift.