### PR TITLE
Add a weekly CI run to build using latest sljit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,50 +36,41 @@ jobs:
       run: sudo apt install ${{ matrix.compiler }} libpcap-dev
 
     - name: Setup CMake
-      uses: jwlawson/actions-setup-cmake@v1
+      uses: jwlawson/actions-setup-cmake@v2
       with:
         cmake-version: ${{ matrix.cmake-version }}
 
-    - uses: actions/checkout@v3
-
-    - name: Create install folder
-      run: cmake -E make_directory $RUNNER_TEMP/install
+    - uses: actions/checkout@v4
 
     - name: Download, build and install dependency sljit
       run: |
+        mkdir -p $RUNNER_TEMP/install
         DESTDIR=$RUNNER_TEMP/install \
         USE_SLJIT_COMMIT=${{ env.USE_SLJIT_COMMIT }} \
         make install-sljit
 
-    - name: Create build folder
-      run: cmake -E make_directory build
-
     - name: Generate makefiles
-      shell: bash
       env:
         CC: ${{ matrix.compiler }}
-      working-directory: build
-      run: cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_PREFIX_PATH=$RUNNER_TEMP/install ..
+      run: |
+        mkdir build && cd build
+        cmake -DCMAKE_BUILD_TYPE=${{ matrix.cmake-build-type }} -DCMAKE_PREFIX_PATH=$RUNNER_TEMP/install ..
 
     - name: Build bpfjit
-      shell: bash
       working-directory: build
       run: VERBOSE=1 make
 
     - name: Install bpfjit
-      shell: bash
       working-directory: build
       run: DESTDIR=$RUNNER_TEMP/install make install
 
     - name: Build and run tests via CMake
-      shell: bash
       working-directory: build
       run: |
         make bpfjit-test && ./bpfjit-test
         make bpfjit-test-with-pcap && ./bpfjit-test-with-pcap
 
     - name: Build and run tests via Makefile
-      shell: bash
       env:
         CC: ${{ matrix.compiler }}
       run: |

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,39 @@
+name: Weekly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 9 * * 1' # Mon 09.00 UTC
+
+jobs:
+  build:
+    name: Build using latest sljit
+    runs-on: ubuntu-24.04
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Prepare
+      run: |
+        sudo apt install libpcap-dev
+    - name: Download, build and install latest sljit
+      run: |
+        mkdir -p $RUNNER_TEMP/install
+        DESTDIR=$RUNNER_TEMP/install make install-sljit
+    - name: Generate makefiles
+      run: |
+        mkdir build && cd build
+        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_PREFIX_PATH=$RUNNER_TEMP/install ..
+    - name: Build and install bpfjit
+      working-directory: build
+      run: |
+        VERBOSE=1 make
+        DESTDIR=$RUNNER_TEMP/install make install
+    - name: Build and run tests via CMake
+      working-directory: build
+      run: |
+        make bpfjit-test && ./bpfjit-test
+        make bpfjit-test-with-pcap && ./bpfjit-test-with-pcap
+    - name: Build and run tests via Makefile
+      run: |
+        PREFIX=$RUNNER_TEMP/install/usr/local make test
+        PREFIX=$RUNNER_TEMP/install/usr/local make test-with-pcap

--- a/test/pcap-helpers.c
+++ b/test/pcap-helpers.c
@@ -23,9 +23,11 @@ struct bpf_program* pcap_filter_compile(const char* filter, size_t snaplen) {
     struct bpf_program *program = malloc(sizeof(struct bpf_program));
     assert(program);
 
-    int ret = pcap_compile_nopcap(snaplen, linktype, program,
-                                  filter, optimize, mask);
+    pcap_t *p = pcap_open_dead(linktype, snaplen);
+    assert(p);
+    int ret = pcap_compile(p, program, filter, optimize, mask);
     assert(ret >= 0);
+    pcap_close(p);
 
     return program;
 }


### PR DESCRIPTION
The new weekly run will indicate when there is a need to update the patch files and bpfjit.


- Replace the deprecated function `pcap_compile_nopcap` in test.
  `pcap_compile_nopcap` is deprecated from `libpcap 1.11.0` which is available in `ubuntu-24.04` used in new weekly runs.
  Use `pcap_open_dead`, `pcap_compile` and `pcap_close` instead as suggested.
- Cleanup CI and update used dependencies.
