### PR TITLE
Update actions/checkout for node.js 24 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       with:
         cmake-version: ${{ matrix.cmake-version }}
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Download, build and install dependency sljit
       run: |

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Prepare
       run: |
         sudo apt install libpcap-dev


### PR DESCRIPTION
Node.js 20 will be removed from runners on September 16th, 2026.